### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-on-commit.yml
+++ b/.github/workflows/build-on-commit.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build and Publish
-        uses: elgohr/Publish-Docker-Github-Action@757f58a82c2851acf641d0410b80e98680811614
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: rpedde/pt750/pt750
           username: ${{ github.actor }}

--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build and Publish
-        uses: elgohr/Publish-Docker-Github-Action@757f58a82c2851acf641d0410b80e98680811614
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: rpedde/pt750/pt750
           username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore