### PR TITLE
fix token permissions to allow container push

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -1,4 +1,4 @@
-name: Build and push container images
+name: container build
 
 on:
   push:
@@ -11,9 +11,11 @@ on:
       - "master"
 
 jobs:
-  docker:
+  build-and-maybe-push:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: pre-commit and unit tests
+name: unit-tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   unit-test:
-    name: unit-test code base
+    name: run unit tests
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Previously, builds succeeded, but pushes to the container registry failed.